### PR TITLE
Fix argument parsing overflow in shell programs

### DIFF
--- a/myhistory.c
+++ b/myhistory.c
@@ -106,15 +106,13 @@ int main(int argc, char *argv[]) {
         }
 
         // Construct the argument list for the command executable
-        char *args[10] = {
-                NULL
-        };
+        char *args[11] = { NULL };
         int i = 0;
 
         args[i++] = token;
         char valid = 0;
         while ((token = strtok(NULL, " ")) != NULL) {
-            if (i > 10) {
+            if (i >= 10) {
                 fprintf(stderr, "Error: Too many arguments\n");
                 break;
             }

--- a/myshell.c
+++ b/myshell.c
@@ -80,13 +80,13 @@ int main(int argc, char *argv[]) {
         }
 
         // Construct the argument list for the command executable
-        char *args[10] = {NULL};
+        char *args[11] = {NULL};
         int i = 0;
 
         args[i++] = token;
         char valid = 0;
         while ((token = strtok(NULL, " ")) != NULL) {
-            if (i > 10) {
+            if (i >= 10) {
                 fprintf(stderr, "ERROR: Too many arguments\n");
                 break;
             }


### PR DESCRIPTION
## Summary
- fix possible overflow when more than 9 parameters are supplied
- allow room for terminating `NULL`

## Testing
- `make myshell`
- `make myhistory`


------
https://chatgpt.com/codex/tasks/task_e_6841edd7e9ac832795c86e9eb0865a91