### PR TITLE
Fix user detection fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Project exclude paths
 /cmake-build-debug/
+myshell
+myhistory

--- a/myhistory.c
+++ b/myhistory.c
@@ -11,6 +11,8 @@
 #include <sys/wait.h>
 
 #include <sys/utsname.h>
+#include <sys/types.h>
+#include <pwd.h>
 
 #define MAX_PATH_LENGTH 1024
 
@@ -41,6 +43,11 @@ int main(int argc, char *argv[]) {
     int device_return = uname(&device_buffer);
     binary_path = "/usr/bin";
     user = getenv("USER"); // Get the current user's name
+    if (user == NULL) {
+        struct passwd *pw = getpwuid(getuid());
+        if (pw != NULL)
+            user = pw->pw_name;
+    }
     user_home = getenv("HOME");
     user_home_len = (int) strlen(user_home);
 

--- a/myshell.c
+++ b/myshell.c
@@ -6,6 +6,8 @@
 #include <sys/wait.h>
 #include <sys/utsname.h>
 #include <errno.h>
+#include <sys/types.h>
+#include <pwd.h>
 
 #define MAX_PATH_LENGTH 1024
 #define DEBUG 0
@@ -14,6 +16,11 @@ int main(int argc, char *argv[]) {
     char input_buffer[80];
     char *binary_path = "/usr/bin";
     char *user = getenv("USER"); // Get the current user's name
+    if (user == NULL) {
+        struct passwd *pw = getpwuid(getuid());
+        if (pw != NULL)
+            user = pw->pw_name;
+    }
     char *user_home = getenv("HOME");
     int user_home_len = (int) strlen(user_home);
     char cwd[PATH_MAX]; // Create a buffer to store the current working directory


### PR DESCRIPTION
## Summary
- ignore built shell binaries
- detect username using `getpwuid` if `USER` isn't set
- apply same fix for `myhistory`

## Testing
- `make myshell myhistory`
- `./myshell <<'EOF'
exit
EOF`
- `./myhistory <<'EOF'
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6841ef817b0883279740bf739c0050d8